### PR TITLE
Prevent proxy-injection for Helm Hook Job Pod

### DIFF
--- a/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
+++ b/jaeger/charts/linkerd-jaeger/templates/namespace-metadata.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         {{ include "partials.annotations.created-by" . }}
+        linkerd.io/inject: disabled
       labels:
         app.kubernetes.io/name: namespace-metadata
         app.kubernetes.io/part-of: Linkerd

--- a/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
+++ b/multicluster/charts/linkerd-multicluster/templates/namespace-metadata.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         {{ include "partials.annotations.created-by" . }}
+        linkerd.io/inject: disabled
       labels:
         app.kubernetes.io/name: namespace-metadata
         app.kubernetes.io/part-of: Linkerd

--- a/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
+++ b/viz/charts/linkerd-viz/templates/namespace-metadata.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         {{ include "partials.annotations.created-by" . }}
+        linkerd.io/inject: disabled
       labels:
         app.kubernetes.io/name: namespace-metadata
         app.kubernetes.io/part-of: Linkerd


### PR DESCRIPTION
Prevent proxy-injection for Helm Hook Job Pod for namespace-metadata, as the injected proxy would prevent the Job from terminating. See also https://github.com/linkerd/linkerd2/issues/8194, which was closed but the Problem still exists.

Fixes #8194

Signed-off-by: Alex Berger <alex-berger@gmx.ch>
